### PR TITLE
chore: clojure-lsp task

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ clojure -M:dev:test
 clojure -T:build uberjar
 ```
 
+## Lint
+```bash
+clojure -M:clojure-lsp diagnostics
+clojure -M:clojure-lsp clean-ns
+clojure -M:clojure-lsp format
+```
+
 # Other iterations
 - https://github.com/rafaeldelboni/clojure-document-extractor
 

--- a/deps.edn
+++ b/deps.edn
@@ -31,4 +31,7 @@
           :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
   :test {:main-opts ["-m" "kaocha.runner"]
-         :jvm-opts  ["-Xms3g" "-Xmx3g"]}}}
+         :jvm-opts  ["-Xms3g" "-Xmx3g"]}
+
+  :clojure-lsp {:replace-deps {com.github.clojure-lsp/clojure-lsp-standalone {:mvn/version "2024.04.22-11.50.26"}}
+                :main-opts ["-m" "clojure-lsp.main"]}}}


### PR DESCRIPTION
This PR adds a `clojure-lsp` task so that lint tasks can be executed locally as well.